### PR TITLE
Improve route uniqueness and POI scoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,8 +98,13 @@ def main():
 
                 # Get alternatives within time constraint
                 alternatives = get_alternative_routes(
-                    google_maps_key, origin, destination, travel_mode,
-                    baseline['duration'], max_extra_time
+                    google_maps_key,
+                    origin,
+                    destination,
+                    travel_mode,
+                    baseline['duration'],
+                    max_extra_time,
+                    baseline['polyline'],
                 )
 
                 # Combine and score all routes

--- a/modules/route_scorer.py
+++ b/modules/route_scorer.py
@@ -47,8 +47,18 @@ def calculate_heuristic_score(route: Dict, pois: List[Dict], preferences: Dict[s
 
 def score_with_openai(route: Dict, pois: List[Dict], preferences: Dict[str, int]) -> Dict[str, Any]:
     """Get AI explanation and refined score"""
-    
-    # Build context for AI
+    if not pois:
+        heuristic_score = calculate_heuristic_score(route, pois, preferences)
+        explanation = "No notable places were found along this route."
+        if route.get('extra_time_percent', 0) > 0:
+            explanation += f" Takes {route['extra_time_percent']:.0f}% extra time."
+        return {
+            'score': heuristic_score,
+            'explanation': explanation,
+            'method': 'heuristic'
+        }
+
+    # Build context for AI using real POIs only
     poi_summary = []
     for poi in pois[:8]:  # Limit to top 8 to stay within token limits
         rating_text = f"({poi.get('rating', 'N/A')}⭐)" if poi.get('rating') else ""
@@ -65,6 +75,7 @@ Route info:
 
 User preferences (they care most about): {', '.join(active_prefs) if active_prefs else 'general exploration'}
 
+Use only the places listed above and do not invent new locations.
 Rate this route 1-10 for "interestingness" and write 2-3 sentences explaining why someone should (or shouldn't) take this path. Be conversational and specific about what makes it special.
 
 Format your response as:


### PR DESCRIPTION
## Summary
- Deduplicate alternative routes by polyline and require baseline polyline when fetching alternatives
- Avoid hallucinated POIs by skipping OpenAI scoring when no real places are found and strengthening prompt instructions
- Pass baseline polyline when requesting alternatives so duplicate routes are filtered

## Testing
- `python -m py_compile app.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68b608bdf0d0832f8962bd21a5feb879