### PR TITLE
Remove unused architecture preference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Diversion is a Python Streamlit application that finds scenic and interesting routes between two locations. The app goes beyond simple directions by discovering points of interest (POIs) along alternative routes and scoring them based on user preferences like scenic areas, food spots, cultural sites, and architecture.
+Diversion is a Python Streamlit application that finds scenic and interesting routes between two locations. The app goes beyond simple directions by discovering points of interest (POIs) along alternative routes and scoring them based on user preferences like scenic areas, food spots, cultural sites, and walkability.
 
 ## Development Commands
 
@@ -55,6 +55,6 @@ pip install -r requirements.txt
 ### Scoring Algorithm
 Routes are scored on a 1-10 scale considering:
 - POI density and quality (rating threshold: 3.5+)
-- User preference matching (food, culture, scenic, architecture, walkable)
+- User preference matching (food, culture, scenic, walkable)
 - Time penalty for routes significantly longer than baseline
 - AI-generated explanations when OpenAI API is available

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://diversion.streamlit.app/
 - **POI-Based Scoring**: Discovers restaurants, parks, museums, and cultural sites along routes
 - **AI-Powered Recommendations**: Uses OpenAI to explain why each route is interesting
 - **Interactive Maps**: Visual route comparison with POI markers
-- **Customizable Preferences**: Weight routes by scenic areas, food, culture, architecture, and walkability
+- **Customizable Preferences**: Weight routes by scenic areas, food, culture, and walkability
 
 ## Quick Start
 

--- a/app.py
+++ b/app.py
@@ -72,14 +72,12 @@ def main():
     st.sidebar.header("What makes a route better?")
     
     preferences = {
-        'scenic': st.sidebar.slider('Scenic areas', 0, 5, 3, 
+        'scenic': st.sidebar.slider('Scenic areas', 0, 5, 3,
                                    help="Parks, waterfront, tree-lined streets"),
         'food': st.sidebar.slider('Food & drink', 0, 5, 3,
                                  help="Cafes, restaurants, food markets"),
         'culture': st.sidebar.slider('Cultural spots', 0, 5, 2,
                                     help="Museums, galleries, bookstores"),
-        'architecture': st.sidebar.slider('Interesting buildings', 0, 5, 2,
-                                         help="Historic or unique architecture"),
         'walkable': st.sidebar.slider('Pedestrian-friendly', 0, 5, 4,
                                      help="Wide sidewalks, pedestrian areas")
     }

--- a/config/settings.py
+++ b/config/settings.py
@@ -29,7 +29,6 @@ POI_TYPE_MAPPING = {
     'food': ['restaurant', 'cafe', 'bakery', 'meal_takeaway'],
     'culture': ['museum', 'art_gallery', 'library', 'book_store'],
     'scenic': ['park', 'tourist_attraction', 'natural_feature'],
-    'architecture': ['place_of_worship', 'city_hall', 'courthouse'],
     'walkable': ['pedestrian_street', 'plaza']
 }
 

--- a/modules/poi_enricher.py
+++ b/modules/poi_enricher.py
@@ -25,8 +25,7 @@ def find_pois_along_route(api_key: str, route_points: List[Tuple[float, float]],
     preference_type_map = {
         'food': ['restaurant', 'cafe', 'bakery'],
         'culture': ['museum', 'art_gallery', 'library'],
-        'scenic': ['park', 'tourist_attraction'],
-        'architecture': ['place_of_worship', 'city_hall']
+        'scenic': ['park', 'tourist_attraction']
     }
 
     # Sort active preference categories by weight (highest first)

--- a/modules/route_scorer.py
+++ b/modules/route_scorer.py
@@ -28,9 +28,7 @@ def calculate_heuristic_score(route: Dict, pois: List[Dict], preferences: Dict[s
         'art_gallery': preferences.get('culture', 0),
         'library': preferences.get('culture', 0),
         'park': preferences.get('scenic', 0),
-        'tourist_attraction': preferences.get('scenic', 0),
-        'place_of_worship': preferences.get('architecture', 0),
-        'city_hall': preferences.get('architecture', 0)
+        'tourist_attraction': preferences.get('scenic', 0)
     }
     
     for poi in pois:


### PR DESCRIPTION
## Summary
- drop "Interesting buildings" slider and architecture preference
- strip architecture handling from POI search and route scoring
- update documentation to reflect remaining preferences

## Testing
- `python -m py_compile app.py modules/route_scorer.py modules/poi_enricher.py config/settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b612fa10b4832f8f85be56d26e2ab0